### PR TITLE
Minor typo fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -383,7 +383,7 @@
 
 - dfacb04: Rename buildCall interface for consistency and clarity
 - e2d66ce: Adds Initialize Pool functionality for V3 pools;
-- c071850: Refactor useNativeAssetAsWrappedAmountIn adn toNativeAsset into wethIsEth
+- c071850: Refactor useNativeAssetAsWrappedAmountIn and toNativeAsset into wethIsEth
 - 7bc308a: Move accountAddress from query to buildCall input
 
 ### Patch Changes


### PR DESCRIPTION
# Minor Typo Fix in CHANGELOG.md

## Description
Corrected a typo:
- Changed `adn` to `and` in the entry for `c071850`.

---

This PR is ready for review. 🚀
